### PR TITLE
Initial implementation for Zod and TypeBox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+/.idea
+/package-lock.json

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "node_modules/@biomejs/biome/configuration_schema.json",
+	"javascript": {
+		"formatter": {
+			"arrowParentheses": "always",
+			"indentStyle": "space",
+			"semicolons": "asNeeded",
+			"trailingComma": "all",
+			"lineWidth": 100,
+			"quoteStyle": "single"
+		}
+	},
+	"linter": {
+		"rules": {
+			"style": {
+				"noUnusedTemplateLiteral": "off"
+			},
+			"correctness": {},
+			"suspicious": {},
+			"complexity": {
+				"noBannedTypes": "off"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@validator-facade/parent",
+  "version": "1.0.0",
+  "dependencies": {
+  },
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "lint": "npm run lint --workspaces",
+    "lint:fix": "npm run lint:fix --workspaces",
+    "test": "npm run test --workspaces"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,0 +1,2 @@
+export type {Validator} from './lib/facadeTypes'
+export { ValidationError, type ValidationErrorOptions, type ValidationErrorEntry } from './lib/ValidationError'

--- a/packages/core/lib/ValidationError.ts
+++ b/packages/core/lib/ValidationError.ts
@@ -1,0 +1,22 @@
+export type ValidationErrorEntry = {
+  path: string
+  message: string
+  schemaDescription: string
+  value?: unknown
+}
+
+export type ValidationErrorOptions = {
+  message: string
+  errors: ValidationErrorEntry[]
+}
+
+export class ValidationError extends Error {
+  public readonly isValidationError = true
+  public readonly errors: ValidationErrorEntry[]
+
+  constructor(options: ValidationErrorOptions) {
+    super(options.message)
+
+    this.errors = options.errors
+  }
+}

--- a/packages/core/lib/facadeTypes.ts
+++ b/packages/core/lib/facadeTypes.ts
@@ -1,0 +1,3 @@
+export type Validator<T> = {
+  parse(target: unknown): T
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@validator-facade/core",
+  "version": "1.0.0",
+  "private": false,
+  "license": "MIT",
+  "description": "Validator facade core",
+  "maintainers": [
+    {
+      "name": "Igor Savin",
+      "email": "kibertoad@gmail.com"
+    }
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "lint": "biome lint index.ts lib ../../biome.json",
+    "lint:fix": "biome check --apply lib ../../biome.json",
+    "test": ""
+  },
+  "dependencies": {
+  },
+  "peerDependencies": {
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.7.3",
+    "@types/node": "^20.12.8",
+    "@vitest/coverage-v8": "^1.6.0",
+    "del-cli": "^5.1.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "homepage": "https://github.com/kibertoad/validator-facade",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kibertoad/validator-facade.git"
+  },
+  "keywords": [
+    "validation",
+    "facade",
+    "validator"
+  ],
+  "files": [
+    "README.md",
+    "LICENSE",
+    "dist/*"
+  ]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": false,
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "importHelpers": true,
+    "baseUrl": ".",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["lib/**/*.ts", "test/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/tsconfig.release.json
+++ b/packages/core/tsconfig.release.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts"]
+}

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    watch: false,
+    environment: 'node',
+  },
+})

--- a/packages/typebox/index.ts
+++ b/packages/typebox/index.ts
@@ -1,0 +1,1 @@
+export { TypeboxValidator } from './lib/TypeboxValidator'

--- a/packages/typebox/lib/TypeboxValidator.spec.ts
+++ b/packages/typebox/lib/TypeboxValidator.spec.ts
@@ -1,0 +1,68 @@
+import { Type } from '@sinclair/typebox'
+import type { ValidationError } from '@validator-facade/core'
+import { describe, expect, it } from 'vitest'
+import { TypeboxValidator } from './TypeboxValidator'
+
+const validator = new TypeboxValidator(
+  Type.Object(
+    {
+      id: Type.String(),
+      age: Type.Number(),
+    },
+    {
+      description: 'Test object',
+    },
+  ),
+)
+
+describe('TypeboxValidator', () => {
+  describe('parse', () => {
+    it('throws an error for invalid schema', () => {
+      expect.assertions(2)
+      try {
+        validator.parse({
+          id: 123,
+        })
+      } catch (err) {
+        const error = err as ValidationError
+        expect(error).toMatchInlineSnapshot(`[Error: Validation error]`)
+        expect(error.errors).toMatchInlineSnapshot(`
+                      [
+                        {
+                          "message": "Required property",
+                          "path": "/age",
+                          "schemaDescription": "Test object",
+                          "value": undefined,
+                        },
+                        {
+                          "message": "Expected string",
+                          "path": "/id",
+                          "schemaDescription": "Test object",
+                          "value": 123,
+                        },
+                        {
+                          "message": "Expected number",
+                          "path": "/age",
+                          "schemaDescription": "Test object",
+                          "value": undefined,
+                        },
+                      ]
+                    `)
+      }
+    })
+
+    it('returns an entity for correct schema', () => {
+      const entity = validator.parse({
+        id: '123',
+        age: 33,
+      })
+
+      expect(entity).toMatchInlineSnapshot(`
+              {
+                "age": 33,
+                "id": "123",
+              }
+            `)
+    })
+  })
+})

--- a/packages/typebox/lib/TypeboxValidator.ts
+++ b/packages/typebox/lib/TypeboxValidator.ts
@@ -1,0 +1,36 @@
+import type { StaticDecode, TSchema } from '@sinclair/typebox'
+import type { TypeCheck } from '@sinclair/typebox/build/cjs/compiler/compiler'
+import { TypeCompiler, type ValueError } from '@sinclair/typebox/compiler'
+import { ValidationError, type ValidationErrorEntry, type Validator } from '@validator-facade/core'
+
+export class TypeboxValidator<T extends TSchema, R = StaticDecode<T>> implements Validator<R> {
+  private readonly checker: TypeCheck<TSchema>
+  private readonly schema: TSchema
+
+  constructor(schema: T) {
+    this.checker = TypeCompiler.Compile<TSchema>(schema)
+    this.schema = schema
+  }
+
+  parse(target: unknown): R {
+    try {
+      const result = this.checker.Decode(target)
+      return result as R
+    } catch (err) {
+      const errors = Array.from(this.checker.Errors(target))
+      throw new ValidationError({
+        message: 'Validation error',
+        errors: errors.map((entry) => this.mapToCoreErrors(entry)),
+      })
+    }
+  }
+
+  private mapToCoreErrors(error: ValueError): ValidationErrorEntry {
+    return {
+      message: error.message,
+      schemaDescription: this.schema.description ?? 'Schema without description',
+      path: error.path,
+      value: error.value,
+    }
+  }
+}

--- a/packages/typebox/lib/TypeboxValidator.ts
+++ b/packages/typebox/lib/TypeboxValidator.ts
@@ -1,6 +1,5 @@
 import type { StaticDecode, TSchema } from '@sinclair/typebox'
-import type { TypeCheck } from '@sinclair/typebox/build/cjs/compiler/compiler'
-import { TypeCompiler, type ValueError } from '@sinclair/typebox/compiler'
+import { type TypeCheck, TypeCompiler, type ValueError } from '@sinclair/typebox/compiler'
 import { ValidationError, type ValidationErrorEntry, type Validator } from '@validator-facade/core'
 
 export class TypeboxValidator<T extends TSchema, R = StaticDecode<T>> implements Validator<R> {

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@validator-facade/typebox",
+  "version": "1.0.0",
+  "description": "Typebox adapter for the validator-facade ",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "biome lint index.ts lib ../../biome.json",
+    "lint:fix": "biome check --apply lib ../../biome.json",
+    "test": "vitest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kibertoad/validator-facade.git"
+  },
+  "peerDependencies": {
+    "@validator-facade/core": "^1.0.0",
+    "zod": "^3.23.6"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.7.3",
+    "@sinclair/typebox": "^0.32.29",
+    "@types/node": "^20.12.8",
+    "@vitest/coverage-v8": "^1.6.0",
+    "del-cli": "^5.1.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "private": false
+}

--- a/packages/typebox/tsconfig.json
+++ b/packages/typebox/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": false,
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "importHelpers": true,
+    "baseUrl": ".",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["lib/**/*.ts", "test/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/typebox/tsconfig.release.json
+++ b/packages/typebox/tsconfig.release.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts"]
+}

--- a/packages/typebox/vitest.config.mts
+++ b/packages/typebox/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    watch: false,
+    environment: 'node',
+  },
+})

--- a/packages/zod/index.ts
+++ b/packages/zod/index.ts
@@ -1,0 +1,1 @@
+export { ZodValidator } from './lib/ZodValidator'

--- a/packages/zod/lib/ZodValidator.spec.ts
+++ b/packages/zod/lib/ZodValidator.spec.ts
@@ -1,0 +1,57 @@
+import type { ValidationError } from '@validator-facade/core'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { ZodValidator } from './ZodValidator'
+
+const validator = new ZodValidator(
+  z
+    .object({
+      id: z.string(),
+      age: z.number(),
+    })
+    .describe('Test object'),
+)
+
+describe('ZodValidator', () => {
+  describe('parse', () => {
+    it('throws an error for invalid schema', () => {
+      expect.assertions(2)
+      try {
+        validator.parse({
+          id: 123,
+        })
+      } catch (err) {
+        const error = err as ValidationError
+        expect(error).toMatchInlineSnapshot(`[Error: Validation error]`)
+        expect(error.errors).toMatchInlineSnapshot(`
+                  [
+                    {
+                      "message": "Expected string, received number",
+                      "path": "id",
+                      "schemaDescription": "Test object",
+                    },
+                    {
+                      "message": "Required",
+                      "path": "age",
+                      "schemaDescription": "Test object",
+                    },
+                  ]
+                `)
+      }
+    })
+
+    it('returns an entity for correct schema', () => {
+      const entity = validator.parse({
+        id: '123',
+        age: 33,
+      })
+
+      expect(entity).toMatchInlineSnapshot(`
+              {
+                "age": 33,
+                "id": "123",
+              }
+            `)
+    })
+  })
+})

--- a/packages/zod/lib/ZodValidator.ts
+++ b/packages/zod/lib/ZodValidator.ts
@@ -1,0 +1,30 @@
+import { ValidationError, type ValidationErrorEntry, type Validator } from '@validator-facade/core'
+import type { ZodError, ZodIssue, ZodSchema } from 'zod'
+
+export class ZodValidator<T> implements Validator<T> {
+  private readonly schema: ZodSchema
+
+  constructor(schema: ZodSchema<T>) {
+    this.schema = schema
+  }
+
+  parse(target: unknown): T {
+    try {
+      return this.schema.parse(target)
+    } catch (err) {
+      const error = err as ZodError
+      throw new ValidationError({
+        message: 'Validation error',
+        errors: error.errors.map((entry) => this.mapToCoreErrors(entry)),
+      })
+    }
+  }
+
+  private mapToCoreErrors(error: ZodIssue): ValidationErrorEntry {
+    return {
+      message: error.message,
+      path: error.path.join(':'),
+      schemaDescription: this.schema.description ?? 'Schema without description',
+    }
+  }
+}

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@validator-facade/zod",
+  "version": "1.0.0",
+  "description": "Zod adapter for the validator-facade",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "biome lint index.ts lib ../../biome.json",
+    "lint:fix": "biome check --apply lib ../../biome.json",
+    "test": "vitest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kibertoad/validator-facade.git"
+  },
+  "peerDependencies": {
+    "@validator-facade/core": "^1.0.0",
+    "zod": "^3.23.6"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.7.3",
+    "@types/node": "^20.12.8",
+    "@vitest/coverage-v8": "^1.6.0",
+    "del-cli": "^5.1.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0",
+    "zod": "^3.23.6"
+  },
+  "private": false
+}

--- a/packages/zod/tsconfig.json
+++ b/packages/zod/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": false,
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "importHelpers": true,
+    "baseUrl": ".",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["lib/**/*.ts", "test/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/zod/tsconfig.release.json
+++ b/packages/zod/tsconfig.release.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["lib/**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts"]
+}

--- a/packages/zod/vitest.config.mts
+++ b/packages/zod/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    watch: false,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
This is an early version. The following are not yet supported:

* Safe parse without throwing
* Async parse
* Type coercion (TypeBox transforms could be used there, need to experiment)
* Type inference aliases (e. g. for `z.infer`)
* Extra adapters may make sense, e. g. for `ajv`